### PR TITLE
Enable overriding 'ar'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,5 @@ $(SYSROOT):
 	$(RM) *.o
 	"$(WASM_CC)" $(WASM_CFLAGS) $(WASM_TARGET_FLAGS) --sysroot="$(SYSROOT)" -c $(BASICS_LIBC_SOURCES)
 	mkdir -p "$(SYSROOT)/lib"
-	ar crs "$(SYSROOT)/lib/libc.a" *.o
+	$(AR) crs "$(SYSROOT)/lib/libc.a" *.o
 	$(RM) *.o


### PR DESCRIPTION
Make has a stanard variable for 'ar', it is better to use it to enable
overriding the standard name in non-standard builds (i.e. MinGW).