### PR TITLE
Add more typedefs and struct stat

### DIFF
--- a/basics/include/__struct_stat.h
+++ b/basics/include/__struct_stat.h
@@ -1,0 +1,35 @@
+#ifndef __wasm_sysroot___struct_stat_h
+#define __wasm_sysroot___struct_stat_h
+
+#include <__typedef_dev_t.h>
+#include <__typedef_ino_t.h>
+#include <__typedef_nlink_t.h>
+#include <__typedef_mode_t.h>
+#include <__typedef_uid_t.h>
+#include <__typedef_gid_t.h>
+#include <__typedef_off_t.h>
+#include <__typedef_blksize_t.h>
+#include <__typedef_blkcnt_t.h>
+#include <__struct_timespec.h>
+
+struct stat {
+    dev_t st_dev;
+    ino_t st_ino;
+    nlink_t st_nlink;
+
+    mode_t st_mode;
+    uid_t st_uid;
+    gid_t st_gid;
+    unsigned int __pad0;
+    dev_t st_rdev;
+    off_t st_size;
+    blksize_t st_blksize;
+    blkcnt_t st_blocks;
+
+    struct timespec st_atim;
+    struct timespec st_mtim;
+    struct timespec st_ctim;
+    long long __unused[3];
+};
+
+#endif

--- a/basics/include/__struct_timespec.h
+++ b/basics/include/__struct_timespec.h
@@ -1,0 +1,12 @@
+#ifndef __wasm_sysroot___struct_timespec_h
+#define __wasm_sysroot___struct_timespec_h
+
+#include "__typedef_time_t.h"
+
+/* As specified in POSIX. */
+struct timespec {
+    time_t tv_sec;
+    long tv_nsec;
+};
+
+#endif

--- a/basics/include/__typedef_blkcnt_t.h
+++ b/basics/include/__typedef_blkcnt_t.h
@@ -1,0 +1,7 @@
+#ifndef __wasm_sysroot___typedef_blkcnt_t_h
+#define __wasm_sysroot___typedef_blkcnt_t_h
+
+/* Define these as 64-bit signed integers to support files larger than 2 GiB. */
+typedef long long blkcnt_t;
+
+#endif

--- a/basics/include/__typedef_blksize_t.h
+++ b/basics/include/__typedef_blksize_t.h
@@ -1,0 +1,7 @@
+#ifndef __wasm_sysroot___typedef_blksize_t_h
+#define __wasm_sysroot___typedef_blksize_t_h
+
+/* Define these as 64-bit signed integers to support files larger than 2 GiB. */
+typedef long long blksize_t;
+
+#endif

--- a/basics/include/__typedef_clock_t.h
+++ b/basics/include/__typedef_clock_t.h
@@ -1,2 +1,7 @@
+#ifndef __wasm_sysroot___typedef_clock_t_h
+#define __wasm_sysroot___typedef_clock_t_h
+
 /* Define this as a 64-bit signed integer to avoid wraparounds. */
 typedef long long clock_t;
+
+#endif

--- a/basics/include/__typedef_dev_t.h
+++ b/basics/include/__typedef_dev_t.h
@@ -1,0 +1,7 @@
+#ifndef __wasm_sysroot___typedef_dev_t_h
+#define __wasm_sysroot___typedef_dev_t_h
+
+/* Define these as 64-bit integers to support billions of devices. */
+typedef unsigned long long dev_t;
+
+#endif

--- a/basics/include/__typedef_gid_t.h
+++ b/basics/include/__typedef_gid_t.h
@@ -1,0 +1,6 @@
+#ifndef __wasm_sysroot___typedef_gid_t_h
+#define __wasm_sysroot___typedef_gid_t_h
+
+typedef unsigned gid_t;
+
+#endif

--- a/basics/include/__typedef_ino_t.h
+++ b/basics/include/__typedef_ino_t.h
@@ -1,0 +1,7 @@
+#ifndef __wasm_sysroot___typedef_ino_t_h
+#define __wasm_sysroot___typedef_ino_t_h
+
+/* Define these as 64-bit integers to support billions of inodes. */
+typedef unsigned long long ino_t;
+
+#endif

--- a/basics/include/__typedef_mode_t.h
+++ b/basics/include/__typedef_mode_t.h
@@ -1,0 +1,6 @@
+#ifndef __wasm_sysroot___typedef_mode_t_h
+#define __wasm_sysroot___typedef_mode_t_h
+
+typedef unsigned mode_t;
+
+#endif

--- a/basics/include/__typedef_nlink_t.h
+++ b/basics/include/__typedef_nlink_t.h
@@ -1,0 +1,7 @@
+#ifndef __wasm_sysroot___typedef_nlink_t_h
+#define __wasm_sysroot___typedef_nlink_t_h
+
+/* Define these as 64-bit signed integers to support billions of links. */
+typedef long long nlink_t;
+
+#endif

--- a/basics/include/__typedef_off_t.h
+++ b/basics/include/__typedef_off_t.h
@@ -1,0 +1,7 @@
+#ifndef __wasm_sysroot___typedef_off_t_h
+#define __wasm_sysroot___typedef_off_t_h
+
+/* Define these as 64-bit signed integers to support files larger than 2 GiB. */
+typedef long long off_t;
+
+#endif

--- a/basics/include/__typedef_ssize_t.h
+++ b/basics/include/__typedef_ssize_t.h
@@ -1,0 +1,7 @@
+#ifndef __wasm_sysroot___typedef_ssize_t_h
+#define __wasm_sysroot___typedef_ssize_t_h
+
+/* This is defined to be the same size as size_t. */
+typedef long long ssize_t;
+
+#endif

--- a/basics/include/__typedef_suseconds_t.h
+++ b/basics/include/__typedef_suseconds_t.h
@@ -1,0 +1,8 @@
+#ifndef __wasm_sysroot___typedef_suseconds_t_h
+#define __wasm_sysroot___typedef_suseconds_t_h
+
+/* Define this to be 64-bit as its main use is in struct timeval where the
+   extra space would otherwise be padding. */
+typedef long long suseconds_t;
+
+#endif

--- a/basics/include/__typedef_time_t.h
+++ b/basics/include/__typedef_time_t.h
@@ -1,2 +1,7 @@
+#ifndef __wasm_sysroot___typedef_time_t_h
+#define __wasm_sysroot___typedef_time_t_h
+
 /* Define this as a 64-bit signed integer to avoid the 2038 bug. */
 typedef long long time_t;
+
+#endif

--- a/basics/include/__typedef_uid_t.h
+++ b/basics/include/__typedef_uid_t.h
@@ -1,0 +1,6 @@
+#ifndef __wasm_sysroot___typedef_uid_t_h
+#define __wasm_sysroot___typedef_uid_t_h
+
+typedef unsigned uid_t;
+
+#endif

--- a/basics/include/sys/stat.h
+++ b/basics/include/sys/stat.h
@@ -1,0 +1,10 @@
+#ifndef __wasm_sysroot_sys_stat_h
+#define __wasm_sysroot_sys_stat_h
+
+#include <__struct_stat.h>
+
+#define st_atime st_atim.tv_sec
+#define st_mtime st_mtim.tv_sec
+#define st_ctime st_ctim.tv_sec
+
+#endif

--- a/basics/include/sys/types.h
+++ b/basics/include/sys/types.h
@@ -6,6 +6,11 @@
 
 #include <__typedef_clock_t.h>
 #include <__typedef_time_t.h>
+#include <__typedef_blksize_t.h>
+#include <__typedef_off_t.h>
+#include <__typedef_ssize_t.h>
+#include <__typedef_suseconds_t.h>
+#include <__typedef_nlink_t.h>
 
 /* Define these as 64-bit signed integers to support files larger than 2 GiB. */
 typedef long long blksize_t;

--- a/basics/include/sys/types.h
+++ b/basics/include/sys/types.h
@@ -14,4 +14,11 @@ typedef long long off_t;
 /* This is defined to be the same size as size_t. */
 typedef long ssize_t;
 
+/* Define this to be 64-bit as its main use is in struct timeval where the
+   extra space would otherwise be padding. */
+typedef long long suseconds_t;
+
+/* Follow x32 in defining this as 64-bit. */
+typedef long long nlink_t;
+
 #endif

--- a/basics/include/time.h
+++ b/basics/include/time.h
@@ -6,5 +6,6 @@
 #include <stddef.h>
 
 #include <__typedef_time_t.h>
+#include <__struct_timespec.h>
 
 #endif


### PR DESCRIPTION
This is generally following the [x32 ABI](https://en.wikipedia.org/wiki/X32_ABI) which is a carefully-designed modern 32-bit ABI. `suseconds_t` and `nlink_t` are both defined be 64-bit integers in x32. And at least in the case of `suseconds_t`, this doesn't waste significant space since its main use is to be in a struct with a `time_t` which is also 64-bit, so the extra space would otherwise be padding.
