### PR TITLE
Fix ssize_t redefinition mismatch.

### DIFF
--- a/basics/include/__typedef_ssize_t.h
+++ b/basics/include/__typedef_ssize_t.h
@@ -2,6 +2,6 @@
 #define __wasm_sysroot___typedef_ssize_t_h
 
 /* This is defined to be the same size as size_t. */
-typedef long long ssize_t;
+typedef long ssize_t;
 
 #endif

--- a/basics/include/sys/types.h
+++ b/basics/include/sys/types.h
@@ -12,18 +12,4 @@
 #include <__typedef_suseconds_t.h>
 #include <__typedef_nlink_t.h>
 
-/* Define these as 64-bit signed integers to support files larger than 2 GiB. */
-typedef long long blksize_t;
-typedef long long off_t;
-
-/* This is defined to be the same size as size_t. */
-typedef long ssize_t;
-
-/* Define this to be 64-bit as its main use is in struct timeval where the
-   extra space would otherwise be padding. */
-typedef long long suseconds_t;
-
-/* Follow x32 in defining this as 64-bit. */
-typedef long long nlink_t;
-
 #endif

--- a/basics/include/sys/types.h
+++ b/basics/include/sys/types.h
@@ -17,7 +17,7 @@ typedef long long blksize_t;
 typedef long long off_t;
 
 /* This is defined to be the same size as size_t. */
-typedef long ssize_t;
+typedef long long ssize_t;
 
 /* Define this to be 64-bit as its main use is in struct timeval where the
    extra space would otherwise be padding. */


### PR DESCRIPTION
Align definition with comment and previous define in __typedef_ssize_t.h

Not sure this has to be redefined here at all.