### PR TITLE
build: add cmake based build infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+
+cmake_minimum_required(VERSION 3.15)
+
+project(wasi-libc
+  LANGUAGES ASM C)
+
+option(ENABLE_THREADS "enable threads" OFF)
+
+add_compile_options(-target wasm32-unknown-none)
+
+include_directories(SYSTEM basics/include)
+if(ENABLE_THREADS)
+  add_compile_options(-mthread-model posix)
+  add_compile_definitions($<$<COMPILE_LANGUAGE:C>:WASM_THREAD_MODEL_POSIX>)
+else()
+  add_compile_options(-mthread-model single)
+  add_compile_definitions($<$<COMPILE_LANGUAGE:C>:WASM_THREAD_MODEL_SINGLE>)
+endif()
+
+add_library(startup OBJECT
+  basics/libc/crt1.s)
+
+add_library(basics STATIC
+  basics/libc/string.c)
+set_target_properties(basics PROPERTIES
+  OUTPUT_NAME libc-basics)
+
+add_library(dlmalloc
+  dlmalloc/src/wrapper.c)
+set_target_properties(dlmalloc PROPERTIES
+  OUTPUT_NAME libc-dlmalloc)
+target_include_directories(dlmalloc PRIVATE
+  dlmalloc/include)
+
+install(DIRECTORY basics/include
+  DESTINATION .)
+install(FILES $<TARGET_OBJECTS:startup>
+  DESTINATION lib)
+install(TARGETS basics dlmalloc
+  DESTINATION lib)

--- a/cmake/Modules/Platform/wasi.cmake
+++ b/cmake/Modules/Platform/wasi.cmake
@@ -1,0 +1,3 @@
+set(WASI 1)
+set(UNIX 1)
+set(CMAKE_STATIC_LIBRARY_PREFIX)


### PR DESCRIPTION
`make` is not available on Windows.  This adds a cmake based build
system.  This allows building the libc image as the follows:

```
cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=clang -DCMAKE_INSTALL_PREFIX=sysroot -DCMAKE_SYSTEM_NAME=wasi -DCMAKE_MODULE_PATH=cmake/Modules
ninja -C build install
```